### PR TITLE
fix typo in header doc

### DIFF
--- a/ProviderCache.php
+++ b/ProviderCache.php
@@ -34,7 +34,7 @@ class ProviderCache implements Provider
     protected $cache;
 
     /**
-     * How log a result is going to be cached.
+     * How long a result is going to be cached.
      *
      * @var int|null
      */


### PR DESCRIPTION
"How long to store" instead of "How log to store"