### PR TITLE
ArrayCachePool need to be imported first

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -26,7 +26,6 @@ You can  set a cache expiry by passing an integer representing the number of sec
 Make sure to use the ArrayCachePool before calling it's methods
 
 ```php
-use Geocoder\Provider\Cache\ProviderCache;
 use Cache\Adapter\PHPArray\ArrayCachePool;
 
 $httpClient = new \Http\Adapter\Guzzle6\Client();

--- a/Readme.md
+++ b/Readme.md
@@ -23,6 +23,12 @@ You can find compatible drivers on [packagist](https://packagist.org/providers/p
 By default, the result is cached forever. 
 You can  set a cache expiry by passing an integer representing the number of seconds as the third parameter.
 
+Make sure to use the ArrayCachePool
+```php
+use Geocoder\Provider\Cache\ProviderCache;
+use Cache\Adapter\PHPArray\ArrayCachePool;
+```
+
 ```php
 $httpClient = new \Http\Adapter\Guzzle6\Client();
 $provider = new \Geocoder\Provider\GoogleMaps\GoogleMaps($httpClient);

--- a/Readme.md
+++ b/Readme.md
@@ -23,13 +23,12 @@ You can find compatible drivers on [packagist](https://packagist.org/providers/p
 By default, the result is cached forever. 
 You can  set a cache expiry by passing an integer representing the number of seconds as the third parameter.
 
-Make sure to use the ArrayCachePool
+Make sure to use the ArrayCachePool before calling it's methods
+
 ```php
 use Geocoder\Provider\Cache\ProviderCache;
 use Cache\Adapter\PHPArray\ArrayCachePool;
-```
 
-```php
 $httpClient = new \Http\Adapter\Guzzle6\Client();
 $provider = new \Geocoder\Provider\GoogleMaps\GoogleMaps($httpClient);
 


### PR DESCRIPTION
We need to import the ArrayCachePool first so we can use it with the cache provider or use ` $cache = new Cache\Adapter\PHPArray\ArrayCachePool();` instead of `$cache = new ArrayCachePool();`
